### PR TITLE
Removes legacy key authorization from challenge request. Fixes errors when testing with Pebble Server

### DIFF
--- a/src/Carbon.Acme.Tests/Actions/CompleteChallengeRequestTests.cs
+++ b/src/Carbon.Acme.Tests/Actions/CompleteChallengeRequestTests.cs
@@ -10,7 +10,7 @@ namespace Carbon.Acme.Tests
             var action = new CompleteChallengeRequest("url", "123");
             
             Assert.Equal("url", action.Url);
-            Assert.Equal("123", action.KeyAuthorization);
+            //Assert.Equal("123", action.KeyAuthorization);
         }
     }
 }

--- a/src/Carbon.Acme/Actions/CompleteChallengeRequest.cs
+++ b/src/Carbon.Acme/Actions/CompleteChallengeRequest.cs
@@ -8,13 +8,13 @@ namespace Carbon.Acme
         public CompleteChallengeRequest(string url, string keyAuthorization)
         {
             Url              = url              ?? throw new ArgumentNullException(nameof(url));
-            KeyAuthorization = keyAuthorization ?? throw new ArgumentNullException(nameof(keyAuthorization));
+            //KeyAuthorization = keyAuthorization ?? throw new ArgumentNullException(nameof(keyAuthorization));
         }
 
         [IgnoreDataMember]
         public string Url { get; }
         
-        [DataMember(Name = "keyAuthorization", IsRequired = true)]
-        public string KeyAuthorization { get; }
+        //[DataMember(Name = "keyAuthorization", IsRequired = true)]
+        //public string KeyAuthorization { get; }
     }
 }

--- a/src/Carbon.Acme/Carbon.Acme.csproj
+++ b/src/Carbon.Acme/Carbon.Acme.csproj
@@ -15,6 +15,11 @@
     <PackageLicenseUrl>https://github.com/carbon/Acme/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>C:\Code\GitHub\tracking-https\libs\carbon-acme-fork</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Carbon.Jose" Version="0.17.0" />
   </ItemGroup>

--- a/src/Carbon.Acme/Carbon.Acme.csproj
+++ b/src/Carbon.Acme/Carbon.Acme.csproj
@@ -15,11 +15,6 @@
     <PackageLicenseUrl>https://github.com/carbon/Acme/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>C:\Code\GitHub\tracking-https\libs\carbon-acme-fork</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Carbon.Jose" Version="0.17.0" />
   </ItemGroup>


### PR DESCRIPTION
This produces errors when testing against Let's Encrypt's Pebble Server.

From their source code here: 
https://github.com/letsencrypt/pebble/blob/22e0a4bcb418c3805cdc9f80c4cc4e3ff425de24/wfe/wfe.go#L1763

	// Historically challenges were updated by POSTing a KeyAuthorization. This is
	// unnecessary, the server can calculate this itself. We could ignore this if
	// sent (and that's what Boulder will do) but for Pebble we'd like to offer
	// a way to be more aggressive about pushing clients implementations in the
	// right direction, so we treat this as a malformed request.
	if chalResp.KeyAuthorization != nil {
		wfe.sendError(
			acme.MalformedProblem(
				"Challenge response body contained legacy KeyAuthorization field, "+
					"POST body should be `{}`"), response)
		return
	}
